### PR TITLE
2024-01-20

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: "3"
+services:
+  app:
+    build: .
+    volumes:
+      - ./:/go/src
+    tty: true

--- a/main.go
+++ b/main.go
@@ -5,5 +5,8 @@ import (
 )
 
 func main() {
-	fmt.Println("Hello World!")
+	firstName, lastName := "John", "Doe"
+	age := 32
+	const HTTPStatusOK = 200
+	fmt.Println(firstName, lastName, age, "status", HTTPStatusOK)
 }


### PR DESCRIPTION
- 変数は`ver`, `:=`が使えるが`:=`が一般的
- 定数はconst
  - 使ってみた感じ、関数内で定義した定数に対して代入はできないが、関数のスコープ外で定義された定数を関数内で同じ名前で代入みたいなのはできる